### PR TITLE
Fix number can't be shared

### DIFF
--- a/src/components/form/RegisterForm.tsx
+++ b/src/components/form/RegisterForm.tsx
@@ -15,6 +15,7 @@ import { HiOutlineExclamationCircle } from "react-icons/hi"
 import { Toasty } from "../Toasty/Toasty";
 import axios from "axios";
 import Datalist from "../ReusableComponents/DataList";
+import { showErrorToast } from "utils/toast";
 
 interface Country {
   name: string;
@@ -118,6 +119,12 @@ function SignupForm() {
           error.includes("email_1 dup key")
         ) {
           showToast("Email already exists. Please sign in.", "error");
+        } else if (
+          error.includes(
+            "Telephone number already exists. Please use a different number."
+          )
+        ) {
+          showToast("This telephone number is already in use.", "error");
         } else {
           showToast(error, "error");
         }


### PR DESCRIPTION
**PR Description**

This PR fix issue of multiple users from registering with the same phone number.

**Description of tasks that were expected to be completed**

Bug Fix : To prevent multiple users from registering with the same phone number ( ensures each phone number can only be associated with a single user account).
This include add a validation checker that check if  Telephone number already exists or used  in register process by someone else then block he/him to register if number exist and display toast to notify him/her.

**How has this been tested?**

 1. Clone the repository.
 2. Checkout to the 117-phone-numbers-can-be-shared
 3. Run npm install, then npm run dev to verify the app is functioning correctly.
 4. Test the Register first and register at the second time with different details but same phone number then see if it work as expected.

**Track PR (issue number & link)** : #117 

** Screenshots **

Register new user but with used telephone number:

<img width="1440" alt="Screenshot 2024-09-20 at 14 51 32" src="https://github.com/user-attachments/assets/f86751e4-92c4-4411-a7f9-39ea61b2e548">

Register new user with new telephone number:

<img width="1436" alt="Screenshot 2024-09-20 at 14 52 22" src="https://github.com/user-attachments/assets/7e191922-5a84-4c6c-8158-41df7f35ab75">
<img width="1440" alt="Screenshot 2024-09-20 at 14 52 33" src="https://github.com/user-attachments/assets/86ce56b0-a5cb-4fd3-aa24-bd15e9082754">
