### PR TITLE
Fixes documents view buttons

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/components/DocumentPreviewButton.tsx
+++ b/src/components/DocumentPreviewButton.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+
+const DocumentSelector = ({ item }) => {
+    const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+    const toggleDropdown = () => {
+        setIsDropdownOpen(!isDropdownOpen);
+    };
+    const handleDocumentOnClick = (urls: string) => {
+        const url = `#/view-external-document?fileUrl=${encodeURIComponent(urls)}&backUrl=${encodeURIComponent("/")}&title=${encodeURIComponent("Documents Preview")}`;
+        window.open(url, "_blank");
+    };
+    return (
+        <div className="relative inline-block">
+            <button
+                className="bg-blue-500 text-white py-2 px-4 rounded-lg font-semibold hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                onClick={toggleDropdown}
+            >
+                Select Attachment
+            </button>
+
+            {isDropdownOpen && (
+                <ul className="dark:text-white dark:bg-dark-tertiary absolute mt-2 border border-gray-300 rounded-lg shadow-lg w-48 z-50">
+                    {item?.idDocumentUrl && (
+                        <li>
+                            <button
+                                className="w-full text-left px-4 py-2 text-white hover:bg-gray-100 hover:text-blue-500 focus:outline-none"
+                                onClick={() => {
+                                    handleDocumentOnClick(item.idDocumentUrl);
+                                    setIsDropdownOpen(false);
+                                }}
+                            >
+                                ID Card
+                            </button>
+                        </li>
+                    )}
+                    {item?.resumeUrl && (
+                        <li>
+                            <button
+                                className="w-full text-left px-4 py-2 text-white hover:bg-gray-100 hover:text-blue-500 focus:outline-none"
+                                onClick={() => {
+                                    handleDocumentOnClick(item.resumeUrl);
+                                    setIsDropdownOpen(false);
+                                }}
+                            >
+                                Resume
+                            </button>
+                        </li>
+                    )}
+                    {item?.coverLetterUrl && (
+                        <li>
+                            <button
+                                className="w-full text-left px-4 py-2 text-white hover:bg-gray-100 hover:text-blue-500 focus:outline-none"
+                                onClick={() => {
+                                    handleDocumentOnClick(item.coverLetterUrl);
+                                    setIsDropdownOpen(false);
+                                }}
+                            >
+                                Cover Letter
+                            </button>
+                        </li>
+                    )}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export default DocumentSelector;

--- a/src/components/Invitation/ScheduleTechnical.tsx
+++ b/src/components/Invitation/ScheduleTechnical.tsx
@@ -45,9 +45,9 @@ const ScheduleTechnical: React.FC<props> = ({
         setError(null);
         onClose();
         setIsModelOpen((prev)=> !prev);
-        setEmail("");
-        setInvitationLink("");
-        setPlatForm("");
+        // setEmail("");
+        // setInvitationLink("");
+        // setPlatForm("");
       }
     ).catch((error:any) => {
       setIsLoading(false);

--- a/src/components/form/advanceTraineeApplicant.tsx
+++ b/src/components/form/advanceTraineeApplicant.tsx
@@ -28,6 +28,7 @@ const NextStageModal: React.FC<props> = ({ applicantId, stage,status, onClose })
     } else {
     const nextStage = handleNextStage(currentStage);
     await dispatch(AdvanceToNextStage(applicantId, nextStage, comments));
+    setComments("")
     setError("")
     }
   };

--- a/src/pages/TraineApplicant/ApplicantStages.tsx
+++ b/src/pages/TraineApplicant/ApplicantStages.tsx
@@ -31,6 +31,7 @@ import { Link } from "react-router-dom";
 import ScheduleTechnical from "../../components/Invitation/ScheduleTechnical";
 import axios from "axios";
 import { exportToExcel } from "../../utils/exports/exportToExcel";
+import DocumentSelector from "../../components/DocumentPreviewButton";
 
 const ApplicantStages = (props: any) => {
   // New state for search input and search field
@@ -196,11 +197,11 @@ const ApplicantStages = (props: any) => {
       case "Technical Assessment":
         // Use pre-filtered data (filterData)
         data = filterData;
-  
+
         // Call exportToExcel function
         exportToExcel({ data, docName: 'Technical_Assessment_Stage_Data' });
         break;
-  
+
       default:
         toast.error("Invalid stage");
     }
@@ -258,11 +259,10 @@ const ApplicantStages = (props: any) => {
             {stages.map((stage) => (
               <button
                 key={stage.value}
-                className={`text-sm rounded-md px-3 py-2 transition-colors duration-200 ${
-                  filterStages === stage.value
-                    ? "bg-[#0c6a0c] dark:bg-[#56C870] text-white" // Active stage style
-                    : "bg-gray-200 text-gray-800 hover:bg-blue-100" // Inactive stage style
-                }`}
+                className={`text-sm rounded-md px-3 py-2 transition-colors duration-200 ${filterStages === stage.value
+                  ? "bg-[#0c6a0c] dark:bg-[#56C870] text-white" // Active stage style
+                  : "bg-gray-200 text-gray-800 hover:bg-blue-100" // Inactive stage style
+                  }`}
                 onClick={() => {
                   setFilterStages(stage.value);
                   handleFilter(stage.value);
@@ -347,9 +347,9 @@ const ApplicantStages = (props: any) => {
                   </th>
                 }
                 {filterStages &&
-                filterStages !== "All" &&
-                filterData &&
-                filterData.length > 0 ? (
+                  filterStages !== "All" &&
+                  filterData &&
+                  filterData.length > 0 ? (
                   <th className="px-5 py-3 text-left text-xs font-semibold text-gray-600 dark:text-white uppercase tracking-wider">
                     {"Comments"}
                   </th>
@@ -431,48 +431,26 @@ const ApplicantStages = (props: any) => {
                         </td>
                         <td className="px-5 py-5 border-b border-gray-200 dark:border-dark-tertiary text-xs">
                           <span
-                            className={`${
-                              item.applicationPhase === "Rejected"
-                                ? "bg-red-200 text-red-500 font-medium"
-                                : item.applicationPhase === "Admitted"
+                            className={`${item.applicationPhase === "Rejected"
+                              ? "bg-red-200 text-red-500 font-medium"
+                              : item.applicationPhase === "Admitted"
                                 ? "bg-[#0c6a0c] dark:bg-[#1bf84b8d] text-white"
                                 : "bg-blue-100 text-blue-800"
-                            } inline-block px-2 py-2 text-center font-medium rounded-full`}
+                              } inline-block px-2 py-2 text-center font-medium rounded-full`}
                           >
                             {getStageText(item.applicationPhase)}
                           </span>
                         </td>
                         <td className="px-5 py-5 border-b border-gray-200 dark:border-dark-tertiary text-xs relative">
                           <div className="flex flex-wrap gap-4">
-                            {item?.idDocumentUrl && (
-                              <Link
-                                to={`/view-external-document?fileUrl=${encodeURIComponent(item.idDocumentUrl)}&backUrl=${encodeURIComponent("/")}&title=${encodeURIComponent("ID Document")}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                title="Open ID Document"
-                                className="px-4 py-2 bg-blue-500 text-white rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400"
-                              >
-                                ID
-                              </Link>
-                            )}
-                            {item?.resumeUrl && (
-                              <Link
-                                to={`/view-external-document?fileUrl=${encodeURIComponent(item.resumeUrl)}&backUrl=${encodeURIComponent("/")}&title=${encodeURIComponent("Resume Document")}`}
-                                target="_blank"
-                                className="px-4 py-2 bg-blue-500 text-white rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-green-400"
-                              >
-                                Resume
-                              </Link>
-                            )}
-                            {item?.coverLetterUrl && (
-                              <Link
-                                to={`/view-external-document?fileUrl=${encodeURIComponent(item.coverLetterUrl)}&backUrl=${encodeURIComponent("/")}&title=${encodeURIComponent("Cover letter Document")}`}
-                                target="_blank"
-                                className="px-4 py-2 bg-blue-500 text-white rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-red-400"
-                              >
-                                Cover letter
-                              </Link>
-                            )}
+                            <DocumentSelector
+                              item={{
+                                idDocumentUrl: item?.idDocumentUrl,
+                                resumeUrl: item?.resumeUrl,
+                                coverLetterUrl: item?.coverLetterUrl,
+                              }}
+                            />
+
                           </div>
                         </td>
                         <td className="px-5 py-5 border-b border-gray-200 dark:border-dark-tertiary text-xs relative">
@@ -485,9 +463,8 @@ const ApplicantStages = (props: any) => {
                               }}
                             />
                             <div
-                              className={`${
-                                isMore === item._id ? "block" : "hidden"
-                              } absolute  bg-white dark:bg-dark-tertiary  dark:text-white text-base list-none divide-y divide-gray-100 rounded shadow my-4 z-[1]`}
+                              className={`${isMore === item._id ? "block" : "hidden"
+                                } absolute  bg-white dark:bg-dark-tertiary  dark:text-white text-base list-none divide-y divide-gray-100 rounded shadow my-4 z-[1]`}
                               id="dropdown"
                             >
                               <ul className="py-1" aria-labelledby="dropdown">
@@ -511,12 +488,11 @@ const ApplicantStages = (props: any) => {
                                 </li>
                                 <li>
                                   <div
-                                    className={`${
-                                      item.applicationPhase ===
+                                    className={`${item.applicationPhase ===
                                       "Technical Assessment"
-                                        ? "block"
-                                        : "hidden"
-                                    }`}
+                                      ? "block"
+                                      : "hidden"
+                                      }`}
                                   >
                                     <ScheduleTechnical
                                       applicantId={item._id}
@@ -649,15 +625,14 @@ const ApplicantStages = (props: any) => {
                               </li>
                               <li>
                                 <div
-                                  className={`${
-                                    filterStages === "Technical Assessment" &&
+                                  className={`${filterStages === "Technical Assessment" &&
                                     (item.status !== "Moved" ||
                                       item.status !== "Admitted" ||
                                       item.status !== "Rejected" ||
                                       item.status !== "Passed")
-                                      ? "block"
-                                      : "hidden"
-                                  }`}
+                                    ? "block"
+                                    : "hidden"
+                                    }`}
                                 >
                                   <ScheduleTechnical
                                     traineeEmail={item.applicant.email}


### PR DESCRIPTION
# Pull Request Description

## Feature: #247  Fix the buttons to view documents

### What does this PR do?

This PR is for fixing how the buttons that allow the admin to view the documents uploaded by the users are displayed. I removed the buttons and used the select instead. So that the admin will select the document and directly it's displayed in the new tab.

### How Can This Be Manually Tested?
Checkout into `fix-buttons`
1. Login as an Admin
- Login as Admin and click on applications cycles
- Click on any specific cycle you want to review in
- For every applicant see in the documents title so that you can view the document they uploaded. Click on select document and select any document and view it's details in new tab.

### Credentials:
**Admin:**
email: admin@example.com
password: password123

# Issue Nnumber:
#247 


**Current**
![image](https://github.com/user-attachments/assets/7ad3d049-54cf-45e7-8f1a-2b17912f2588)

**Updated**
![image](https://github.com/user-attachments/assets/c2411dbe-f293-4447-8f71-140b96d47a56)
